### PR TITLE
Ajustado mapper de game para normalizar as tags

### DIFF
--- a/src/fcg.GameService.Application/Mappers/Registers/GameMappingRegister.cs
+++ b/src/fcg.GameService.Application/Mappers/Registers/GameMappingRegister.cs
@@ -1,3 +1,4 @@
+using fcg.GameService.Application.Helpers;
 using fcg.GameService.Domain.Entities;
 using fcg.GameService.Presentation.DTOs.Game.Requests;
 using fcg.GameService.Presentation.DTOs.Game.Responses;
@@ -15,7 +16,7 @@ public class GameMappingRegister : IRegister
                 dto.Name,
                 dto.Price,
                 dto.ReleasedDate,
-                dto.Tags,
+                TagHelper.NormalizeTags(dto.Tags),
                 dto.Description
             ));
 


### PR DESCRIPTION
Após alguns testes, foi verificado que as tags não estavam mais realizando a normalização, removendo a acentuação e adicionando o separador - entre elas. Realizada a correção necessária.